### PR TITLE
Log errors, don't return them to the chat.

### DIFF
--- a/LinksBot.py
+++ b/LinksBot.py
@@ -32,7 +32,7 @@ class LinksBot(BotPlugin):
         Check if there are links in the message
         and if so return the title of the target page and it's real url
         """
-        results = self.regex_parser.links(message.getBody())
+        results = self.regex_parser.links(message.body)
         return_message = error = ''
 
         for res in results:
@@ -49,6 +49,6 @@ class LinksBot(BotPlugin):
                 return_message = '{0} ({1})'.format(
                     BeautifulSoup(page.read()).title.string, page.url)
 
-            self.send(message.getFrom(),
+            self.send(message.frm,
                       return_message,
-                      message_type=message.getType())
+                      message_type=message.type)

--- a/LinksBot.py
+++ b/LinksBot.py
@@ -6,7 +6,9 @@ from urllib.error import HTTPError
 from errbot import BotPlugin, botcmd
 from bs4 import BeautifulSoup
 from commonregex import CommonRegex
+import logging
 
+log = logging.getLogger('errbot.plugins.LinksBot')
 
 class LinksBot(BotPlugin):
 
@@ -39,12 +41,15 @@ class LinksBot(BotPlugin):
             try:
                 page = urlopen(res)
             except HTTPError as e:
+                log.warning("HTTP Error while fetching {0}: {1}".format(res, e))
                 error = e
 
             if error or page.getcode() != 200:
                 return_message = (
                     'An error occured while trying to open this link: {0}{1}'
                 ).format(res, '\n==>: ' + str(error) if error else '')
+                log.warning(return_message)
+                continue
             else:
                 return_message = '{0} ({1})'.format(
                     BeautifulSoup(page.read()).title.string, page.url)

--- a/LinksBot.py
+++ b/LinksBot.py
@@ -27,7 +27,7 @@ class LinksBot(BotPlugin):
         """
         return "This plugin decode your links, and that's all for now!"
 
-    def callback_message(self, connection, message):
+    def callback_message(self, message):
         """
         Check if there are links in the message
         and if so return the title of the target page and it's real url


### PR DESCRIPTION
Often times a link will be posted to a site that requires sign-in. LinksBot will report a 403 to the chat which isn't helpful or accurate.
This patch treats those errors as simple warnings and logs them, but does not clutter the chat with it.
This could be made a configuration option, but that doesn't suit my own needs.

This pull request also incorporates #2 (which fixes #1).